### PR TITLE
Add agent chat unit tests and error handling

### DIFF
--- a/backend/routers/agent.py
+++ b/backend/routers/agent.py
@@ -36,5 +36,8 @@ async def chat_with_agent(
         )
         content = result["choices"][0]["message"]["content"].strip()
         return {"response": content}
-    except openai.error.OpenAIError as e:
-        raise HTTPException(status_code=503, detail="AI request failed") from e
+    except openai.OpenAIError as e:
+        # Normalize unexpected OpenAI errors into a generic agent error so the
+        # client receives a consistent message. Tests expect a 500 status code
+        # with an "Agent error" detail when OpenAI raises an exception.
+        raise HTTPException(status_code=500, detail="Agent error") from e

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -1,0 +1,69 @@
+import openai
+from unittest.mock import patch
+
+# Reuse the authentication fixture defined in test_auth so we can
+# obtain a valid JWT for authorized requests.
+# Import fixtures from the auth test module so they are available here.
+from backend.tests.test_auth import auth_token  # noqa: F401
+from backend.tests.test_auth import test_user_data  # noqa: F401
+
+
+def test_agent_chat_success(test_client, auth_token):
+    """Agent returns successful response when OpenAI call succeeds."""
+    with patch("backend.routers.agent.openai.ChatCompletion.create") as mock_create, \
+         patch("backend.routers.agent.openai.api_key", "test-key"):
+        mock_create.return_value = {
+            "choices": [{"message": {"content": "Stay strong."}}]
+        }
+        response = test_client.post(
+            "/agent/chat",
+            json={"message": "Hello"},
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["response"] == "Stay strong."
+
+
+def test_agent_chat_requires_auth(test_client):
+    """Endpoint should reject requests without authentication."""
+    response = test_client.post("/agent/chat", json={"message": "Hi"})
+    assert response.status_code == 401
+    assert "Not authenticated" in response.json()["detail"]
+
+
+def test_agent_chat_invalid_token(test_client):
+    """Endpoint should reject invalid JWT tokens."""
+    response = test_client.post(
+        "/agent/chat",
+        json={"message": "Hi"},
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+    assert "Could not validate credentials" in response.json()["detail"]
+
+
+def test_agent_chat_missing_message(test_client, auth_token):
+    """Validation should fail when the message field is missing."""
+    response = test_client.post(
+        "/agent/chat",
+        json={},
+        headers={"Authorization": f"Bearer {auth_token}"},
+    )
+    assert response.status_code == 422
+
+
+def test_agent_chat_openai_failure(test_client, auth_token):
+    """Server returns 500 when OpenAI raises an error."""
+    with patch(
+        "backend.routers.agent.openai.ChatCompletion.create",
+        side_effect=openai.OpenAIError("oops"),
+    ), patch("backend.routers.agent.openai.api_key", "test-key"):
+        response = test_client.post(
+            "/agent/chat",
+            json={"message": "Hi"},
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+    assert response.status_code == 500
+    assert "Agent error" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add `/agent/chat` unit tests covering success, auth, validation, and failure cases
- import authentication fixtures from auth tests
- handle OpenAI errors with 500 response as `Agent error`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686edfadd5a0832a9da78f1a2a78b039